### PR TITLE
Add recursive eigenmode weight update to EM loop

### DIFF
--- a/nlgc/_nlgc.py
+++ b/nlgc/_nlgc.py
@@ -130,7 +130,7 @@ class NLGC:
 def nlgc_map(name, evoked, forward, noise_cov, labels, order, self_history=None, n_eigenmodes=2, alpha=0.0, beta=0.0,
         patch_idx=[], n_segments=1, loose=0.0, depth=0.0, pca=True, rank=None, lambda_range=None,
         max_iter=500, max_cyclic_iter=3, tol=1e-5, sparsity_factor=0.0, cv=5, use_lapack=True, use_es=True,
-        var_thr=1.0):
+        var_thr=1.0, update_weights=False, weight_prior_var=1.0):
     """NLGC connectivity map estimation
 
     This function estimates the causal connectivity map across sources given the MEG measurements, forward model,
@@ -240,7 +240,8 @@ def nlgc_map(name, evoked, forward, noise_cov, labels, order, self_history=None,
                            ROIs=patch_idx,
                            alpha=alpha, beta=beta, cv=cv, lambda_range=lambda_range, max_iter=max_iter,
                            max_cyclic_iter=max_cyclic_iter, tol=tol, sparsity_factor=sparsity_factor,
-                           use_lapack=use_lapack, use_es=use_es, var_thr=var_thr)
+                           use_lapack=use_lapack, use_es=use_es, var_thr=var_thr,
+                           update_weights=update_weights, weight_prior_var=weight_prior_var)
         d_raw[this_segment] = d_raw_
         bias_r[this_segment] = bias_r_
         bias_f[this_segment] = bias_f_
@@ -255,7 +256,8 @@ def nlgc_map(name, evoked, forward, noise_cov, labels, order, self_history=None,
 
 def _gc_extraction(y, f, r, p, p1, n_eigenmodes=2, var_thr=1.0, ROIs=[], alpha=0, beta=0,
         lambda_range=None, max_iter=500, max_cyclic_iter=3,
-        tol=1e-5, sparsity_factor=0.0, cv=5, use_lapack=True, use_es=True):
+        tol=1e-5, sparsity_factor=0.0, cv=5, use_lapack=True, use_es=True,
+        update_weights=False, weight_prior_var=1.0):
     n, m = f.shape
     nx = m // n_eigenmodes
 
@@ -265,7 +267,9 @@ def _gc_extraction(y, f, r, p, p1, n_eigenmodes=2, var_thr=1.0, ROIs=[], alpha=0
         'beta': beta,
         'max_iter': max_iter,
         'max_cyclic_iter': max_cyclic_iter,
-        'rel_tol': tol
+        'rel_tol': tol,
+        'update_weights': update_weights,
+        'weight_prior_var': weight_prior_var,
     }
 
     # learn the full model

--- a/nlgc/opt/m_step.py
+++ b/nlgc/opt/m_step.py
@@ -400,6 +400,85 @@ def compute_Q(y, x_, s_, b, a, f, q, r, m, p):
     return  val
 
 
+def update_eigenmode_weights(y, x_bar, f_orig, weights, r, prior_mean=1.0, prior_var=1.0):
+    """Update eigenmode weights w inside the EM loop.
+
+    Given smoothed source estimates x_bar from the E-step, update per-eigenmode
+    scalar weights that scale each column of the forward model:
+
+        f_weighted[:, j] = w_j * f_orig[:, j]
+
+    The update maximises the posterior under a Gaussian prior on w:
+
+        w_j ~ N(prior_mean, prior_var)
+
+    using coordinate descent over eigenmodes.
+
+    Parameters
+    ----------
+    y : ndarray of shape (n_samples, n_channels)
+        Sensor data (already transposed, as used inside _fit).
+    x_bar : ndarray of shape (n_samples, n_sources)
+        Smoothed source estimates (first m columns of x_).
+    f_orig : ndarray of shape (n_channels, n_sources)
+        Original (unweighted) forward model.
+    weights : ndarray of shape (n_sources,)
+        Current eigenmode weights.
+    r : ndarray of shape (n_channels, n_channels)
+        Noise covariance.
+    prior_mean : float
+        Prior mean for each weight (default 1.0).
+    prior_var : float
+        Prior variance for each weight (default 1.0).
+
+    Returns
+    -------
+    weights : ndarray of shape (n_sources,)
+        Updated eigenmode weights.
+    """
+    n, m = f_orig.shape
+    t_samples = x_bar.shape[0]
+
+    # R^{-1}  (fast path for diagonal R)
+    r_diag = np.diag(r) if r.ndim == 2 else r * np.ones(n)
+    r_inv_diag = 1.0 / np.maximum(r_diag, 1e-30)
+    # For diagonal R:  f^T R^{-1} f  =  sum_i  f_i^2 / r_i
+
+    # Current weighted prediction:  Y_pred = x_bar @ (f_orig * w)^T   shape (T, n)
+    f_w = f_orig * weights[None, :]           # (n, m)
+    y_pred = x_bar.dot(f_w.T)                 # (T, n)
+
+    for j in range(m):
+        fj = f_orig[:, j]                     # (n,)
+        xj = x_bar[:, j]                      # (T,)
+
+        # Remove old j-th contribution
+        y_pred -= np.outer(xj, fj * weights[j])
+
+        # Residual with j removed
+        residual = y - y_pred                  # (T, n)
+
+        # Sufficient statistics
+        fj_Rinv_fj = np.dot(fj ** 2, r_inv_diag)           # scalar
+        xj_sq = np.dot(xj, xj)                              # scalar
+
+        # Posterior precision  =  likelihood precision + prior precision
+        precision = fj_Rinv_fj * xj_sq + 1.0 / max(prior_var, 1e-30)
+
+        # Posterior information  =  likelihood info + prior info
+        #   likelihood info = fj^T R^{-1} (sum_t residual_t * xj_t)
+        rxj = residual.T.dot(xj)              # (n,)
+        info = np.dot(fj * r_inv_diag, rxj) + prior_mean / max(prior_var, 1e-30)
+
+        if precision > 1e-30:
+            weights[j] = info / precision
+
+        # Add back updated j-th contribution
+        y_pred += np.outer(xj, fj * weights[j])
+
+    return weights
+
+
 def test_solve_for_a_and_q(t=1000):
     # n, m = 155, 6*2*68
     n, m, p, k = 3, 3, 2, 10

--- a/nlgc/opt/opt.py
+++ b/nlgc/opt/opt.py
@@ -14,7 +14,7 @@ from mne.utils import logger
 
 from .e_step import sskf, sskfcv, align_cast, sskf_prediction
 from .m_step import (calculate_ss, solve_for_a, solve_for_q, compute_ll,
-                     compute_cross_ll, compute_Q)
+                     compute_cross_ll, compute_Q, update_eigenmode_weights)
 
 # filename = os.path.realpath(os.path.join(__file__, '..', '..', "debug.log"))
 # logging.basicConfig(filename=filename, level=logging.DEBUG)
@@ -41,6 +41,7 @@ class NeuraLVAR:
     lambda_ = None
     _zeroed_index = None
     restriction = None
+    _eigenmode_weights = None
 
     def __init__(self, order, self_history=None, n_eigenmodes=None, copy=True, standardize=False, normalize=False,
             use_lapack=True):
@@ -62,7 +63,8 @@ class NeuraLVAR:
         self._n_eigenmodes = 1 if n_eigenmodes is None else n_eigenmodes
 
     def _fit(self, y, f, r, lambda2=None, max_iter=500, max_cyclic_iter=3, a_init=None, q_init=None,
-            rel_tol=0.01, xs=None, alpha=0.0, beta=0.0, fixed_a=False, fixed_q=False):
+            rel_tol=0.01, xs=None, alpha=0.0, beta=0.0, fixed_a=False, fixed_q=False,
+            update_weights=False, weight_prior_var=1.0):
         """Internal function that fits the model from given data
 
         Parameters
@@ -124,6 +126,14 @@ class NeuraLVAR:
         ll_s = []
         Qvals = []
         source_fits = []
+
+        # --- eigenmode weight initialisation ---
+        if update_weights:
+            f_orig = f.copy()                       # unweighted forward (n, m)
+            if self._eigenmode_weights is None or self._eigenmode_weights.shape[0] != m:
+                self._eigenmode_weights = np.ones(m, dtype=np.float64)
+        # ----------------------------------------
+
         for i in range(max_iter):
             a_[:m] = a_upper
             q_[non_zero_indices] = q_upper[non_zero_indices]
@@ -158,8 +168,20 @@ class NeuraLVAR:
                 if q_upper.min() < 0:
                     warnings.warn(f'Q possibly contains negative value {q_upper.min()}', RuntimeWarning)
 
+            # --- eigenmode weight update (recursive, based on posterior) ---
+            if update_weights:
+                self._eigenmode_weights = update_eigenmode_weights(
+                    y, x_[:, :m], f_orig, self._eigenmode_weights, r,
+                    prior_mean=1.0, prior_var=weight_prior_var,
+                )
+                # apply updated weights to forward for next E-step
+                f_weighted = f_orig * self._eigenmode_weights[None, :]
+                f_[:, :m] = f_weighted
+                f = f_weighted    # used by compute_ll on next iteration
+            # ---------------------------------------------------------------
+
         a = self._unravel_a(a_upper)
-        return a, q_upper, (lls, ll_s, Qvals, source_fits), f, r, zeroed_index, xs, x_
+        return a, q_upper, (lls, ll_s, Qvals, source_fits), f, r, zeroed_index, xs, x_, self._eigenmode_weights
 
     def compute_ll(self, y, args=None):
         """Returns log(p(y|args=(a, f, q, r))).
@@ -304,7 +326,8 @@ class NeuraLVAR:
         return bias
 
     def fit(self, y, f, r, lambda2=None, max_iter=500, max_cyclic_iter=3, a_init=None, q_init=None, rel_tol=0.0001,
-            restriction=None, alpha=0.0, beta=0.0, use_es=None):
+            restriction=None, alpha=0.0, beta=0.0, use_es=None,
+            update_weights=False, weight_prior_var=1.0):
         """Fits the model from given m/eeg data, forward gain and noise covariance
 
         Parameters
@@ -322,6 +345,10 @@ class NeuraLVAR:
             i and j should be integers.
         alpha: float, default = 0.5
         beta : float, default = 1
+        update_weights : bool, default=False
+            If True, update per-eigenmode weights w inside the EM loop.
+        weight_prior_var : float, default=1.0
+            Prior variance for eigenmode weights (Gaussian prior centered at 1).
 
         Notes
         -----
@@ -333,9 +360,11 @@ class NeuraLVAR:
         if (restriction is None or re.search('->', restriction)) is False:
             raise ValueError(f"restriction:{restriction} should be None or should have format 'i->j'!")
         self.restriction = restriction
-        a, q_upper, lls, f, r, zeroed_index, _, x_ = self._fit(y, f, r, lambda2=lambda2, max_iter=max_iter,
-                                                               max_cyclic_iter=max_cyclic_iter, a_init=a_init,
-                                                               q_init=q_init, rel_tol=rel_tol, alpha=alpha, beta=beta)
+        a, q_upper, lls, f, r, zeroed_index, _, x_, w = self._fit(
+            y, f, r, lambda2=lambda2, max_iter=max_iter,
+            max_cyclic_iter=max_cyclic_iter, a_init=a_init,
+            q_init=q_init, rel_tol=rel_tol, alpha=alpha, beta=beta,
+            update_weights=update_weights, weight_prior_var=weight_prior_var)
         self._parameters = (a, f, q_upper, r, x_)
         self._zeroed_index = zeroed_index
         self._lls = lls
@@ -513,7 +542,7 @@ class NeuraLVARCV(NeuraLVAR):
             if i > 0:
                 a_init = a_.copy()
                 # q_init = q_upper.copy() * lambda_range[i-1] / lambda_range[i]
-            a_, q_upper, lls, _, _, _, xs, _ = \
+            a_, q_upper, lls, _, _, _, xs, _, _ = \
                 self._fit(y_train, f, r, lambda2=lambda2, max_iter=max_iter,
                           max_cyclic_iter=max_cyclic_iter,
                           a_init=a_init, q_init=q_init.copy(), rel_tol=rel_tol, xs=xs, alpha=alpha, beta=beta)
@@ -532,7 +561,8 @@ class NeuraLVARCV(NeuraLVAR):
         return None
 
     def fit(self, y, f, r, lambda_range=None, max_iter=500, max_cyclic_iter=3, a_init=None, q_init=None,
-            rel_tol=1e-5, restriction=None, alpha=0.0, beta=0.0, use_es=True):
+            rel_tol=1e-5, restriction=None, alpha=0.0, beta=0.0, use_es=True,
+            update_weights=False, weight_prior_var=1.0):
         """Fits the model from given m/eeg data, forward gain and noise covariance
 
         y : ndarray of shape (n_channels, n_samples)
@@ -548,6 +578,10 @@ class NeuraLVARCV(NeuraLVAR):
             i and j should be integers.
         alpha: float, default = 0.5
         beta : float, default = 1
+        update_weights : bool, default=False
+            If True, update per-eigenmode weights w inside the EM loop.
+        weight_prior_var : float, default=1.0
+            Prior variance for eigenmode weights (Gaussian prior centered at 1).
 
         Notes
         -----
@@ -560,7 +594,7 @@ class NeuraLVARCV(NeuraLVAR):
 
         y, f = align_cast((y, f), self._use_lapack)  # to make y, f contiguous in 'F'
 
-        if lambda_range is None or lambda_range == 'auto':
+        if lambda_range is None or (isinstance(lambda_range, str) and lambda_range == 'auto'):
             raise NotImplementedError("Try specifying a pre-determined range")
         else:
             if not isinstance(lambda_range, np.ndarray):
@@ -624,9 +658,11 @@ class NeuraLVARCV(NeuraLVAR):
             best_lambda = lambda_range[index]
             print(f'best_regularizing parameter: {best_lambda}')
 
-        a, q_upper, lls, f, r, zeroed_index, _, x_ = self._fit(y, f, r, lambda2=best_lambda, max_iter=max_iter,
-                                                               max_cyclic_iter=max_cyclic_iter, a_init=a_init,
-                                                               q_init=q_init, rel_tol=rel_tol, alpha=alpha, beta=beta)
+        a, q_upper, lls, f, r, zeroed_index, _, x_, w = self._fit(
+            y, f, r, lambda2=best_lambda, max_iter=max_iter,
+            max_cyclic_iter=max_cyclic_iter, a_init=a_init,
+            q_init=q_init, rel_tol=rel_tol, alpha=alpha, beta=beta,
+            update_weights=update_weights, weight_prior_var=weight_prior_var)
         self._parameters = (a, f, q_upper, r, x_)
         self._zeroed_index = zeroed_index
         self._lls = lls


### PR DESCRIPTION
Add update_eigenmode_weights() to m_step.py that updates per-eigenmode scalar weights w inside the EM loop using coordinate descent with a Gaussian prior w_j ~ N(1, sigma^2_w).

The update runs after A and Q updates at each EM iteration:
  E-step:  sskf()         -> smoothed x_bar
  M-step:  solve_for_a()  -> update A
           solve_for_q()  -> update Q
           update_eigenmode_weights() -> update w  (NEW)
  Reweight: f = f_orig * w  -> feeds into next E-step

Controlled by two new parameters on fit():
  - update_weights: bool (default False, fully backward compatible)
  - weight_prior_var: float (default 1.0, smaller = weights stay near 1)

Also fixes: lambda_range == 'auto' ValueError in NeuraLVARCV.fit() when lambda_range is a numpy array.